### PR TITLE
Compliant ids

### DIFF
--- a/handler/artifact.go
+++ b/handler/artifact.go
@@ -6,7 +6,6 @@ import (
 	"github.com/amdonov/lite-idp/saml"
 	"github.com/amdonov/lite-idp/store"
 	"github.com/amdonov/xmlsig"
-	"github.com/satori/go.uuid"
 	"net/http"
 	"time"
 )
@@ -41,7 +40,7 @@ func (handler *artifactHandler) ServeHTTP(writer http.ResponseWriter, request *h
 	}
 	artResponseEnv := protocol.ArtifactResponseEnvelope{}
 	artResponse := &artResponseEnv.Body.ArtifactResponse
-	artResponse.ID = uuid.NewV4().String()
+	artResponse.ID = protocol.NewID()
 	now := time.Now()
 	artResponse.IssueInstant = now
 	artResponse.InResponseTo = resolveEnv.Body.ArtifactResolve.ID

--- a/handler/query.go
+++ b/handler/query.go
@@ -6,7 +6,6 @@ import (
 	"github.com/amdonov/lite-idp/protocol"
 	"github.com/amdonov/lite-idp/saml"
 	"github.com/amdonov/xmlsig"
-	"github.com/satori/go.uuid"
 	"net/http"
 	"time"
 )
@@ -43,7 +42,7 @@ func (handler *queryHandler) ServeHTTP(writer http.ResponseWriter, request *http
 	}
 	var attrResp attributes.AttributeRespEnv
 	resp := &attrResp.Body.Response
-	resp.ID = uuid.NewV4().String()
+	resp.ID = protocol.NewID()
 	resp.InResponseTo = query.ID
 	resp.Version = "2.0"
 	now := time.Now()
@@ -52,7 +51,7 @@ func (handler *queryHandler) ServeHTTP(writer http.ResponseWriter, request *http
 	a := &saml.Assertion{}
 	a.Issuer = resp.Issuer
 	a.IssueInstant = now
-	a.ID = uuid.NewV4().String()
+	a.ID = protocol.NewID()
 	a.Version = "2.0"
 	a.Subject = &saml.Subject{}
 	a.Subject.NameID = query.Subject.NameID

--- a/protocol/post.go
+++ b/protocol/post.go
@@ -18,15 +18,14 @@ func NewPOSTResponseMarshaller(signer xmlsig.Signer) ResponseMarshaller {
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
 "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
-<body onload="document.forms[0].submit()">
+<body onload="document.getElementById('samlpost').submit()">
 <noscript>
 <p>
 <strong>Note:</strong> Since your browser does not support JavaScript,
 you must press the Continue button once to proceed.
 </p>
 </noscript>
-<form action="{{ .AssertionConsumerServiceURL }}"
-method="post">
+<form action="{{ .AssertionConsumerServiceURL }}" method="post" id="samlpost">
 <div>
 <input type="hidden" name="RelayState"
 value="{{ .RelayState }}"/>

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -1,14 +1,19 @@
 package protocol
 
 import (
-	"github.com/amdonov/lite-idp/saml"
-	"github.com/satori/go.uuid"
 	"net/http"
 	"time"
+
+	"github.com/amdonov/lite-idp/saml"
+	"github.com/satori/go.uuid"
 )
 
 type RequestParser interface {
 	Parse(request *http.Request) (*AuthnRequest, string, error)
+}
+
+func NewID() string {
+	return "_" + uuid.NewV4().String()
 }
 
 func NewStatus(success bool) *Status {
@@ -41,7 +46,7 @@ type defaultGenerator struct {
 func (generator *defaultGenerator) Generate(user *AuthenticatedUser, authnRequest *AuthnRequest, attributes map[string][]string) *Response {
 	s := &Response{}
 	s.Version = "2.0"
-	s.ID = uuid.NewV4().String()
+	s.ID = NewID()
 	now := time.Now()
 	fiveMinutes, _ := time.ParseDuration("5m")
 	fiveFromNow := now.Add(fiveMinutes)
@@ -50,7 +55,7 @@ func (generator *defaultGenerator) Generate(user *AuthenticatedUser, authnReques
 	s.InResponseTo = authnRequest.ID
 	s.Issuer = saml.NewIssuer(generator.entityId)
 	assertion := &saml.Assertion{}
-	assertion.ID = uuid.NewV4().String()
+	assertion.ID = NewID()
 	assertion.IssueInstant = now
 	assertion.Version = "2.0"
 	assertion.Issuer = s.Issuer


### PR DESCRIPTION
hello! stumbled upon your library and it really helped out. we're using the IdP segment of the code. this patch fixes the ids generated in the saml payloads. 

apparently, ids must not start with a number. from http://www.datypic.com/sc/xsd/t-xsd_ID.html :

> The type xsd:ID is used for an attribute that uniquely identifies an element in an XML document. An xsd:ID value must be an NCName. This means that it must start with a letter or underscore, and can only contain letters, digits, underscores, hyphens, and periods.


I added a helper protocol.NewID() that will _ prefix the uuids. 


Also, included is a patch to the html generated by protocol/post so that firefox works. 

