### PR TITLE
SAMLv2 timestamps must be in UTC: 

### DIFF
--- a/idp/artifact.go
+++ b/idp/artifact.go
@@ -63,7 +63,7 @@ func (i *IDP) processArtifactResolutionRequest(w http.ResponseWriter, r *http.Re
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	now := time.Now()
+	now := time.Now().UTC()
 	response := i.makeAuthnResponse(artifactResponse.Request, artifactResponse.User)
 	artResponseEnv := saml.ArtifactResponseEnvelope{
 		Body: saml.ArtifactResponseBody{

--- a/idp/query.go
+++ b/idp/query.go
@@ -33,7 +33,7 @@ func (i *IDP) DefaultQueryHandler() http.HandlerFunc {
 					Response: *response,
 				},
 			}
-			now := time.Now()
+			now := time.Now().UTC()
 			fiveMinutes, _ := time.ParseDuration("5m")
 			fiveFromNow := now.Add(fiveMinutes)
 			attrResp := &saml.AttributeRespEnv{

--- a/idp/response.go
+++ b/idp/response.go
@@ -60,7 +60,7 @@ func (i *IDP) respond(authRequest *model.AuthnRequest, user *model.User,
 }
 
 func (i *IDP) makeAuthnResponse(request *model.AuthnRequest, user *model.User) *saml.Response {
-	now := time.Now()
+	now := time.Now().UTC()
 	fiveFromNow := now.Add(5 * time.Minute)
 	resp := i.makeResponse(request.ID, request.Issuer, user)
 	// Add subject confirmation data and authentication statement
@@ -87,7 +87,7 @@ func (i *IDP) makeAuthnResponse(request *model.AuthnRequest, user *model.User) *
 }
 
 func (i *IDP) makeResponse(id, issuer string, user *model.User) *saml.Response {
-	now := time.Now()
+	now := time.Now().UTC()
 	fiveFromNow := now.Add(5 * time.Minute)
 	s := &saml.Response{
 		StatusResponseType: saml.StatusResponseType{

--- a/sp/artifact.go
+++ b/sp/artifact.go
@@ -119,7 +119,7 @@ func (sp *serviceProvider) buildResolveRequest(artifact string) (io.Reader, erro
 			ArtifactResolve: saml.ArtifactResolve{
 				RequestAbstractType: saml.RequestAbstractType{
 					ID:           saml.NewID(),
-					IssueInstant: time.Now(),
+					IssueInstant: time.Now().UTC(),
 					Issuer:       sp.configuration.EntityID,
 					Version:      "2.0",
 				},

--- a/sp/query.go
+++ b/sp/query.go
@@ -55,7 +55,7 @@ func (sp *serviceProvider) buildQueryRequest(nameID string) (io.Reader, error) {
 			Query: saml.AttributeQuery{
 				RequestAbstractType: saml.RequestAbstractType{
 					ID:           saml.NewID(),
-					IssueInstant: time.Now(),
+					IssueInstant: time.Now().UTC(),
 					Issuer:       sp.configuration.EntityID,
 					Version:      "2.0",
 				},

--- a/sp/redirect.go
+++ b/sp/redirect.go
@@ -35,7 +35,7 @@ func (sp *serviceProvider) GetRedirect(state []byte) (string, error) {
 		EntityID string
 	}{
 		saml.NewID(),
-		time.Now().Format(time.RFC3339),
+		time.Now().UTC().Format(time.RFC3339),
 		sp.configuration.IDPRedirectEndpoint,
 		sp.configuration.AssertionConsumerServiceURL,
 		sp.configuration.EntityID,


### PR DESCRIPTION
Standard here:
http://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf #1.3.3 "Time Values"

Some libraries (Notably OneLogin php-saml) will reject responses with timestamps that are not UTC.