### PR TITLE
Remove xml processing instruction from POST form

### DIFF
--- a/idp/post.go
+++ b/idp/post.go
@@ -57,7 +57,7 @@ func (i *IDP) sendPostResponse(authRequest *model.AuthnRequest, user *model.User
 
 //Assume HTML 5, where <head> is not required
 const postTemplate = `<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<html lang="en">
 <body onload="document.getElementById('samlpost').submit()">
 <noscript>
 <p>

--- a/idp/post.go
+++ b/idp/post.go
@@ -55,10 +55,9 @@ func (i *IDP) sendPostResponse(authRequest *model.AuthnRequest, user *model.User
 	return i.postTemplate.Execute(w, data)
 }
 
-const postTemplate = `<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
-"http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+//Assume HTML 5, where <head> is not required
+const postTemplate = `<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
 <body onload="document.getElementById('samlpost').submit()">
 <noscript>
 <p>


### PR DESCRIPTION
Internet Explorer tries to render the form as XML rather than processing the HTML.