### PR TITLE
Transpose retrieval of now time to get a more accurate time

### DIFF
--- a/idp/artifact.go
+++ b/idp/artifact.go
@@ -64,8 +64,8 @@ func (i *IDP) processArtifactResolutionRequest(w http.ResponseWriter, r *http.Re
 		i.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	now := time.Now().UTC()
 	response := i.makeAuthnResponse(artifactResponse.Request, artifactResponse.User)
+	now := time.Now().UTC()
 	artResponseEnv := saml.ArtifactResponseEnvelope{
 		Body: saml.ArtifactResponseBody{
 			ArtifactResponse: saml.ArtifactResponse{


### PR DESCRIPTION
Moved the retrieval of the "now" time to later to get a more accurate time. When the line is earlier, the times can be just barely off. Example (Now is .000003 seconds before NotBefore):

NotBefore:           2020-06-01 17:50:52.703655 +0000 UTC
Now:                     2020-06-01 17:50:52.703652 +0000 UTC
NotOnOrAfter:     2020-06-01 17:55:52.703655 +0000 UTC