### PR TITLE
IDP-124 Use a configurable threshold when validating assertions

### DIFF
--- a/sp/artifact.go
+++ b/sp/artifact.go
@@ -54,7 +54,7 @@ func (sp *serviceProvider) ArtifactFunc(callback ArtifactCallback) http.HandlerF
 		}
 
 		// validate the assertion has a valid time
-		if err = sp.validateAssertion(assertion, time.Now().UTC()); err != nil {
+		if err = sp.validateAssertion(assertion); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
@@ -64,7 +64,8 @@ func (sp *serviceProvider) ArtifactFunc(callback ArtifactCallback) http.HandlerF
 	}
 }
 
-func (sp *serviceProvider) validateAssertion(assertion *saml.Assertion, now time.Time) error {
+func (sp *serviceProvider) validateAssertion(assertion *saml.Assertion) error {
+	now := time.Now().UTC()
 	// get the threshold from configuration, or default it to 0 seconds
 	threshold, err := time.ParseDuration(sp.configuration.Threshold)
 	if err != nil {

--- a/sp/artifact.go
+++ b/sp/artifact.go
@@ -68,14 +68,14 @@ func (sp *serviceProvider) validateAssertion(assertion *saml.Assertion) error {
 	now := time.Now().UTC()
 
 	notOnOrAfter := assertion.Conditions.NotOnOrAfter
-	// check if the "now" time is after the specified time, subtracting the threshold from the time
-	if !notOnOrAfter.IsZero() && now.Add(sp.threshold*-1).After(notOnOrAfter) {
+	// check if the "now" time is after the specified time, subtracting the margin from the time
+	if !notOnOrAfter.IsZero() && now.Add(sp.timestampMargin*-1).After(notOnOrAfter) {
 		return fmt.Errorf("at %s got response that cannot be processed because it expired at %s", now, notOnOrAfter)
 	}
 
 	notBefore := assertion.Conditions.NotBefore
-	// check if the "now" time is before the specified time, adding the threshold to the time
-	if !notBefore.IsZero() && now.Add(sp.threshold).Before(notBefore) {
+	// check if the "now" time is before the specified time, adding the margin to the time
+	if !notBefore.IsZero() && now.Add(sp.timestampMargin).Before(notBefore) {
 		return fmt.Errorf("at %s got response that cannot be processed before %s", now, notBefore)
 	}
 

--- a/sp/artifact.go
+++ b/sp/artifact.go
@@ -66,21 +66,16 @@ func (sp *serviceProvider) ArtifactFunc(callback ArtifactCallback) http.HandlerF
 
 func (sp *serviceProvider) validateAssertion(assertion *saml.Assertion) error {
 	now := time.Now().UTC()
-	// get the threshold from configuration, or default it to 0 seconds
-	threshold, err := time.ParseDuration(sp.configuration.Threshold)
-	if err != nil {
-		threshold = 0 * time.Second
-	}
 
 	notOnOrAfter := assertion.Conditions.NotOnOrAfter
 	// check if the "now" time is after the specified time, subtracting the threshold from the time
-	if !notOnOrAfter.IsZero() && now.Add(threshold*-1).After(notOnOrAfter) {
+	if !notOnOrAfter.IsZero() && now.Add(sp.threshold*-1).After(notOnOrAfter) {
 		return fmt.Errorf("at %s got response that cannot be processed because it expired at %s", now, notOnOrAfter)
 	}
 
 	notBefore := assertion.Conditions.NotBefore
 	// check if the "now" time is before the specified time, adding the threshold to the time
-	if !notBefore.IsZero() && now.Add(threshold).Before(notBefore) {
+	if !notBefore.IsZero() && now.Add(sp.threshold).Before(notBefore) {
 		return fmt.Errorf("at %s got response that cannot be processed before %s", now, notBefore)
 	}
 

--- a/sp/artifact_test.go
+++ b/sp/artifact_test.go
@@ -167,9 +167,9 @@ func Test_serviceProvider_validateAssertionWithThreshold(t *testing.T) {
 		EntityID:                    "https://test/",
 		AssertionConsumerServiceURL: "http://test",
 		TLSConfig:                   tlsConfigClient,
-		Threshold:                   "1m",
+		TimestampMargin:             1 * time.Minute,
 	})
-	// valid assertion with the threshold
+	// valid assertion with the margin
 	assertion := &saml.Assertion{
 		Conditions: &saml.Conditions{
 			NotBefore:    time.Now(),
@@ -178,22 +178,22 @@ func Test_serviceProvider_validateAssertionWithThreshold(t *testing.T) {
 	}
 	err = sp.(*serviceProvider).validateAssertion(assertion)
 	assert.Equal(t, nil, err)
-	// assertion that is before the NotBefore time but the threshold makes it pass
+	// assertion that is before the NotBefore time but the margin makes it pass
 	assertion.Conditions.NotBefore = time.Now().Add(time.Minute * 1)
 	err = sp.(*serviceProvider).validateAssertion(assertion)
 	assert.Equal(t, nil, err)
-	// assertion that is before the NotBefore time and past the threshold
+	// assertion that is before the NotBefore time and past the margin
 	assertion.Conditions.NotBefore = time.Now().Add(time.Minute * 5)
 	err = sp.(*serviceProvider).validateAssertion(assertion)
 	assert.NotEqual(t, nil, err)
 	assert.Contains(t, err.Error(), "got response that cannot be processed before")
 	// reset NotBefore
 	assertion.Conditions.NotBefore = time.Now()
-	// assertion that is after the NotOnOrAfter time but the threshold makes it pass
+	// assertion that is after the NotOnOrAfter time but the margin makes it pass
 	assertion.Conditions.NotOnOrAfter = time.Now().Add(time.Minute * -1)
 	err = sp.(*serviceProvider).validateAssertion(assertion)
 	assert.Equal(t, nil, err)
-	// assertion that is after the NotOnOrAfter time and past the threshold
+	// assertion that is after the NotOnOrAfter time and past the margin
 	assertion.Conditions.NotOnOrAfter = time.Now().Add(time.Minute * -5)
 	err = sp.(*serviceProvider).validateAssertion(assertion)
 	assert.NotEqual(t, nil, err)

--- a/sp/sp.go
+++ b/sp/sp.go
@@ -46,6 +46,7 @@ type Configuration struct {
 	Timeout   time.Duration
 	TLSConfig *tls.Config
 	Cache     store.Cache
+	Threshold string
 }
 
 // New creates a service provider from the provided configuration

--- a/sp/sp.go
+++ b/sp/sp.go
@@ -69,12 +69,18 @@ func New(conf Configuration) (ServiceProvider, error) {
 				TLSClientConfig: conf.TLSConfig,
 			}}
 	}
+	// get the threshold from configuration, or default it to 0 seconds
+	threshold, err := time.ParseDuration(conf.Threshold)
+	if err != nil {
+		threshold = 0 * time.Second
+	}
 	serviceProvider := &serviceProvider{
 		configuration:   conf,
 		requestTemplate: templ,
 		signer:          signer,
 		client:          client,
 		stateCache:      conf.Cache,
+		threshold:       threshold,
 	}
 
 	return serviceProvider, nil
@@ -86,4 +92,5 @@ type serviceProvider struct {
 	signer          xmlsig.Signer
 	client          *http.Client
 	stateCache      store.Cache
+	threshold       time.Duration
 }

--- a/sp/sp.go
+++ b/sp/sp.go
@@ -42,11 +42,11 @@ type Configuration struct {
 	IDPQueryEndpoint            string
 	// Optional override of client added for testing
 	// but may have other uses
-	Client    *http.Client
-	Timeout   time.Duration
-	TLSConfig *tls.Config
-	Cache     store.Cache
-	Threshold string
+	Client          *http.Client
+	Timeout         time.Duration
+	TLSConfig       *tls.Config
+	Cache           store.Cache
+	TimestampMargin time.Duration
 }
 
 // New creates a service provider from the provided configuration
@@ -69,18 +69,13 @@ func New(conf Configuration) (ServiceProvider, error) {
 				TLSClientConfig: conf.TLSConfig,
 			}}
 	}
-	// get the threshold from configuration, or default it to 0 seconds
-	threshold, err := time.ParseDuration(conf.Threshold)
-	if err != nil {
-		threshold = 0 * time.Second
-	}
 	serviceProvider := &serviceProvider{
 		configuration:   conf,
 		requestTemplate: templ,
 		signer:          signer,
 		client:          client,
 		stateCache:      conf.Cache,
-		threshold:       threshold,
+		timestampMargin: conf.TimestampMargin,
 	}
 
 	return serviceProvider, nil
@@ -92,5 +87,5 @@ type serviceProvider struct {
 	signer          xmlsig.Signer
 	client          *http.Client
 	stateCache      store.Cache
-	threshold       time.Duration
+	timestampMargin time.Duration
 }


### PR DESCRIPTION
Use a configurable threshold value when validating assertions so it won't intermittently fail by being off by less than a second, add test