### PR TITLE
check URL parameters for requestId when logging in with a password

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 certs/
 .vscode/
 dist/
+lite-idp

--- a/idp/password.go
+++ b/idp/password.go
@@ -78,7 +78,11 @@ func (i *IDP) DefaultPasswordLoginHandler() http.HandlerFunc {
 			if err != nil {
 				return err
 			}
-			requestID := r.Form.Get("requestId")
+			var requestID string
+			if requestID = r.Form.Get("requestId"); requestID == `` {
+				//try pulling it from a query parameter
+				requestID = r.URL.Query().Get("requestId")
+			}
 			data, err := i.TempCache.Get(requestID)
 			if err != nil {
 				return err


### PR DESCRIPTION
updating the password login form to check the query parameter for the `requestId` too.


Several of the SAML SP providers send this request ID as a query parameter which will not show up in the request Form.  This checks the query parameter if the Form doesn't have the value.